### PR TITLE
Refactor Civitai API integration

### DIFF
--- a/Services.LoraAutoSort/Services/CivitaiApiClient.cs
+++ b/Services.LoraAutoSort/Services/CivitaiApiClient.cs
@@ -1,0 +1,38 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Services.LoraAutoSort.Services
+{
+    /// <summary>
+    /// Default implementation for communicating with the Civitai API.
+    /// </summary>
+    public class CivitaiApiClient : ICivitaiApiClient
+    {
+        private readonly HttpClient _httpClient;
+
+        public CivitaiApiClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+
+            if (_httpClient.BaseAddress == null)
+            {
+                _httpClient.BaseAddress = new Uri("https://civitai.com/api/v1/");
+            }
+        }
+
+        public async Task<string> GetModelVersionByHashAsync(string sha256Hash)
+        {
+            HttpResponseMessage response = await _httpClient.GetAsync($"model-versions/by-hash/{sha256Hash}");
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        public async Task<string> GetModelAsync(string modelId)
+        {
+            HttpResponseMessage response = await _httpClient.GetAsync($"models/{modelId}");
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
+    }
+}
+

--- a/Services.LoraAutoSort/Services/ICivitaiApiClient.cs
+++ b/Services.LoraAutoSort/Services/ICivitaiApiClient.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace Services.LoraAutoSort.Services
+{
+    /// <summary>
+    /// Abstraction over the Civitai HTTP API. Allows mocking in tests and
+    /// centralises all endpoint calls.
+    /// </summary>
+    public interface ICivitaiApiClient
+    {
+        Task<string> GetModelVersionByHashAsync(string sha256Hash);
+        Task<string> GetModelAsync(string modelId);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `ICivitaiApiClient` interface and `CivitaiApiClient` implementation
- inject the API client into `CivitaiMetaDataService`
- simplify `CivitaiMetaDataService` by removing direct `HttpClient` usage
- add small helper methods for URL parsing

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849de212e788332b228087fbebc072e