### PR TITLE
Add full Civitai API support and API key handling

### DIFF
--- a/Services.LoraAutoSort/Classes/SelectedOptions.cs
+++ b/Services.LoraAutoSort/Classes/SelectedOptions.cs
@@ -8,5 +8,10 @@
         public bool OverrideFiles { get; set; }
         public bool CreateBaseFolders { get; set; }
         public bool UseCustomMappings { get; set; }
+        /// <summary>
+        /// Optional Civitai API key used for authenticated requests.
+        /// Leave empty to perform anonymous requests.
+        /// </summary>
+        public string ApiKey { get; set; } = string.Empty;
     }
 }

--- a/Services.LoraAutoSort/Services/CivitaiApiClient.cs
+++ b/Services.LoraAutoSort/Services/CivitaiApiClient.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace Services.LoraAutoSort.Services
@@ -20,18 +21,76 @@ namespace Services.LoraAutoSort.Services
             }
         }
 
-        public async Task<string> GetModelVersionByHashAsync(string sha256Hash)
+        private async Task<string> SendGetAsync(string url, string apiKey)
         {
-            HttpResponseMessage response = await _httpClient.GetAsync($"model-versions/by-hash/{sha256Hash}");
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            if (!string.IsNullOrWhiteSpace(apiKey))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("ApiKey", apiKey);
+            }
+
+            HttpResponseMessage response = await _httpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();
         }
 
-        public async Task<string> GetModelAsync(string modelId)
+        public Task<string> GetModelVersionByHashAsync(string sha256Hash, string apiKey = "")
         {
-            HttpResponseMessage response = await _httpClient.GetAsync($"models/{modelId}");
-            response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsStringAsync();
+            return SendGetAsync($"model-versions/by-hash/{sha256Hash}", apiKey);
+        }
+
+        public Task<string> GetModelAsync(string modelId, string apiKey = "")
+        {
+            return SendGetAsync($"models/{modelId}", apiKey);
+        }
+
+        public Task<string> GetModelsAsync(string query = "", string apiKey = "")
+        {
+            var path = string.IsNullOrWhiteSpace(query) ? "models" : $"models?{query}";
+            return SendGetAsync(path, apiKey);
+        }
+
+        public Task<string> GetModelVersionAsync(string versionId, string apiKey = "")
+        {
+            return SendGetAsync($"model-versions/{versionId}", apiKey);
+        }
+
+        public Task<string> GetModelVersionsByModelIdAsync(string modelId, string apiKey = "")
+        {
+            return SendGetAsync($"models/{modelId}/versions", apiKey);
+        }
+
+        public Task<string> GetImagesAsync(string query = "", string apiKey = "")
+        {
+            var path = string.IsNullOrWhiteSpace(query) ? "images" : $"images?{query}";
+            return SendGetAsync(path, apiKey);
+        }
+
+        public Task<string> GetImageAsync(string imageId, string apiKey = "")
+        {
+            return SendGetAsync($"images/{imageId}", apiKey);
+        }
+
+        public Task<string> GetTagsAsync(string query = "", string apiKey = "")
+        {
+            var path = string.IsNullOrWhiteSpace(query) ? "tags" : $"tags?{query}";
+            return SendGetAsync(path, apiKey);
+        }
+
+        public Task<string> GetUserAsync(string userId, string apiKey = "")
+        {
+            return SendGetAsync($"users/{userId}", apiKey);
+        }
+
+        public Task<string> GetPostsAsync(string query = "", string apiKey = "")
+        {
+            var path = string.IsNullOrWhiteSpace(query) ? "posts" : $"posts?{query}";
+            return SendGetAsync(path, apiKey);
+        }
+
+        public Task<string> GetPostAsync(string postId, string apiKey = "")
+        {
+            return SendGetAsync($"posts/{postId}", apiKey);
         }
     }
 }

--- a/Services.LoraAutoSort/Services/FileControllerService.cs
+++ b/Services.LoraAutoSort/Services/FileControllerService.cs
@@ -19,7 +19,7 @@ namespace Services.LoraAutoSort.Services
             // Throw if cancellation is requested
             cancellationToken.ThrowIfCancellationRequested();
 
-            var jsonReader = new JsonInfoFileReaderService(options.BasePath);
+            var jsonReader = new JsonInfoFileReaderService(options.BasePath, options.ApiKey);
             List<ModelClass> models = await jsonReader.GetModelData(progress, options.BasePath, cancellationToken);
 
             if (models == null || models.Count == 0)

--- a/Services.LoraAutoSort/Services/ICivitaiApiClient.cs
+++ b/Services.LoraAutoSort/Services/ICivitaiApiClient.cs
@@ -8,8 +8,17 @@ namespace Services.LoraAutoSort.Services
     /// </summary>
     public interface ICivitaiApiClient
     {
-        Task<string> GetModelVersionByHashAsync(string sha256Hash);
-        Task<string> GetModelAsync(string modelId);
+        Task<string> GetModelVersionByHashAsync(string sha256Hash, string apiKey = "");
+        Task<string> GetModelAsync(string modelId, string apiKey = "");
+        Task<string> GetModelsAsync(string query = "", string apiKey = "");
+        Task<string> GetModelVersionAsync(string versionId, string apiKey = "");
+        Task<string> GetModelVersionsByModelIdAsync(string modelId, string apiKey = "");
+        Task<string> GetImagesAsync(string query = "", string apiKey = "");
+        Task<string> GetImageAsync(string imageId, string apiKey = "");
+        Task<string> GetTagsAsync(string query = "", string apiKey = "");
+        Task<string> GetUserAsync(string userId, string apiKey = "");
+        Task<string> GetPostsAsync(string query = "", string apiKey = "");
+        Task<string> GetPostAsync(string postId, string apiKey = "");
     }
 }
 

--- a/Services.LoraAutoSort/Services/JsonInfoFileReaderService.cs
+++ b/Services.LoraAutoSort/Services/JsonInfoFileReaderService.cs
@@ -16,10 +16,12 @@ namespace Services.LoraAutoSort.Services
     public class JsonInfoFileReaderService
     {
         private readonly string _loraInfoBasePath;
+        private readonly string _apiKey;
 
-        public JsonInfoFileReaderService(string jsonFilePath)
+        public JsonInfoFileReaderService(string jsonFilePath, string apiKey)
         {
             _loraInfoBasePath = jsonFilePath;
+            _apiKey = apiKey;
         }
         /// <summary>
         /// Parses the safetensor file at the given path and returns the __metadata__ JSON element.
@@ -189,7 +191,7 @@ namespace Services.LoraAutoSort.Services
             var fileCivitai = model.AssociatedFilesInfo.FirstOrDefault(x => x.FullName.Contains(".civitai.info"));
             if (fileCivitai != null)
             {
-                CivitaiMetaDataService civitaiMetaDataService = new CivitaiMetaDataService();
+                CivitaiMetaDataService civitaiMetaDataService = new CivitaiMetaDataService(_apiKey);
                 // Read file content as a JSON string
                 string jsonContent = File.ReadAllText(fileCivitai.FullName);
 
@@ -223,7 +225,7 @@ namespace Services.LoraAutoSort.Services
 
                 //string SafetensorModelHash = ParseSafetensorsMetadata(SafetensorsFileInfo);
                 string SHA256FromSafetensorsFile = ComputeSHA256(SafetensorsFileInfo.FullName);
-                CivitaiMetaDataService service = new CivitaiMetaDataService();
+                CivitaiMetaDataService service = new CivitaiMetaDataService(_apiKey);
                 //First API call to get info from the specific model version, some loras have a Pony, Flux, SDXL version
                 string modelVersionInfoApiResponse = await service.GetModelVersionInformationFromCivitaiAsync(SHA256FromSafetensorsFile);
                 string modelId = service.GetModelId(modelVersionInfoApiResponse);

--- a/UI.LoraSort/UserControls/AppSettingsTopLeftControl.xaml.cs
+++ b/UI.LoraSort/UserControls/AppSettingsTopLeftControl.xaml.cs
@@ -109,7 +109,8 @@ namespace UI.LoraSort
                     IsMoveOperation = moveOperation,
                     OverrideFiles = (bool)chbOverride.IsChecked,
                     CreateBaseFolders = (bool)chbBaseFolders.IsChecked,
-                    UseCustomMappings = (bool)chbCustom.IsChecked
+                    UseCustomMappings = (bool)chbCustom.IsChecked,
+                    ApiKey = SettingsManager.LoadApiKey()
                 });
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
## Summary
- track API key in `SelectedOptions`
- use API key when calling Civitai and expose more endpoints
- wire API key through `JsonInfoFileReaderService` and `FileControllerService`
- load saved API key in UI when processing

## Testing
- `dotnet build LoraAutoSort.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e719510483328970ff887701d534