### PR TITLE
Fix pipeline for Windows build

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,4 +23,4 @@ jobs:
       run: dotnet build --no-restore --configuration Release
 
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --configuration Release --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
- use `windows-latest` runner for the .NET build pipeline

## Testing
- `dotnet restore` *(fails: NETSDK1100 on linux)*

------
https://chatgpt.com/codex/tasks/task_e_684a943ddb688332b4eb0df55edb6f4d