### PR TITLE
Enhance custom tag map tests

### DIFF
--- a/LorasAutoSort.Test/FileCopyServiceTests.cs
+++ b/LorasAutoSort.Test/FileCopyServiceTests.cs
@@ -371,7 +371,7 @@ namespace LorasAutoSort.Test
             };
             var mapping2 = new CustomTagMap
             {
-                LookForTag = new List<string> { "beta", "four", "five" },
+                LookForTag = new List<string> { "four", "beta", "five" },
                 MapToFolder = "MatchSecond",
                 Priority = 2
             };

--- a/LorasAutoSort.Test/FileCopyServiceTests.cs
+++ b/LorasAutoSort.Test/FileCopyServiceTests.cs
@@ -10,14 +10,17 @@ namespace LorasAutoSort.Test
         private readonly string _testSourcePath;
         private readonly string _testTargetPath;
         private readonly FileCopyService _service;
+        private readonly string _mappingFilePath;
 
         public FileCopyServiceTests()
         {
             _testSourcePath = Path.Combine(Path.GetTempPath(), "LoraAutoSortTests_Source");
             _testTargetPath = Path.Combine(Path.GetTempPath(), "LoraAutoSortTests_Target");
             _service = new FileCopyService();
+            _mappingFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "mappings.xml");
 
             SetupTestDirectories();
+            DeleteMappingFile();
         }
 
         private void SetupTestDirectories()
@@ -29,6 +32,14 @@ namespace LorasAutoSort.Test
                     Directory.Delete(path, true);
                 }
                 Directory.CreateDirectory(path);
+            }
+        }
+
+        private void DeleteMappingFile()
+        {
+            if (File.Exists(_mappingFilePath))
+            {
+                File.Delete(_mappingFilePath);
             }
         }
 
@@ -176,6 +187,252 @@ namespace LorasAutoSort.Test
         }
 
         [Fact]
+        public void ProcessModelClasses_WithCustomMapping_NoMatch_ShouldUseDefaultPath()
+        {
+            var modelFile = "test_model.safetensors";
+            var modelFilePath = Path.Combine(_testSourcePath, modelFile);
+            File.WriteAllText(modelFilePath, "test content");
+
+            var models = new List<ModelClass>
+            {
+                new ModelClass
+                {
+                    ModelName = "test_model",
+                    AssociatedFilesInfo = new List<FileInfo> { new FileInfo(modelFilePath) },
+                    NoMetaData = false,
+                    DiffusionBaseModel = "SD 1.5",
+                    CivitaiCategory = CivitaiBaseCategories.CHARACTER,
+                    ModelType = DiffusionTypes.LORA,
+                    Tags = new List<string> { "custom_tag" }
+                }
+            };
+
+            var customMapping = new CustomTagMap
+            {
+                LookForTag = new List<string> { "other_tag" },
+                MapToFolder = "OtherFolder",
+                Priority = 0
+            };
+
+            var options = new SelectedOptions
+            {
+                TargetPath = _testTargetPath,
+                CreateBaseFolders = true,
+                IsMoveOperation = false,
+                OverrideFiles = true,
+                UseCustomMappings = true
+            };
+
+            var xmlService = new CustomTagMapXmlService();
+            xmlService.SaveMappings(new ObservableCollection<CustomTagMap> { customMapping });
+
+            var progress = new Progress<ProgressReport>();
+            var cts = new CancellationTokenSource();
+
+            bool result = _service.ProcessModelClasses(progress, cts.Token, models, options);
+
+            result.Should().BeFalse();
+            var expectedPath = Path.Combine(_testTargetPath, "SD 1.5", "CHARACTER", modelFile);
+            File.Exists(expectedPath).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ProcessModelClasses_WithMultipleTagsInMapping_ShouldMatchAnyTag()
+        {
+            var modelFile = "test_model.safetensors";
+            var modelFilePath = Path.Combine(_testSourcePath, modelFile);
+            File.WriteAllText(modelFilePath, "test content");
+
+            var models = new List<ModelClass>
+            {
+                new ModelClass
+                {
+                    ModelName = "test_model",
+                    AssociatedFilesInfo = new List<FileInfo> { new FileInfo(modelFilePath) },
+                    NoMetaData = false,
+                    DiffusionBaseModel = "SD 1.5",
+                    CivitaiCategory = CivitaiBaseCategories.CHARACTER,
+                    ModelType = DiffusionTypes.LORA,
+                    Tags = new List<string> { "TAG2" }
+                }
+            };
+
+            var customMapping = new CustomTagMap
+            {
+                LookForTag = new List<string> { "tag1", "tag2" },
+                MapToFolder = "CustomFolder",
+                Priority = 0
+            };
+
+            var options = new SelectedOptions
+            {
+                TargetPath = _testTargetPath,
+                CreateBaseFolders = true,
+                IsMoveOperation = false,
+                OverrideFiles = true,
+                UseCustomMappings = true
+            };
+
+            var xmlService = new CustomTagMapXmlService();
+            xmlService.SaveMappings(new ObservableCollection<CustomTagMap> { customMapping });
+
+            var progress = new Progress<ProgressReport>();
+            var cts = new CancellationTokenSource();
+
+            bool result = _service.ProcessModelClasses(progress, cts.Token, models, options);
+
+            result.Should().BeFalse();
+            var expectedPath = Path.Combine(_testTargetPath, "SD 1.5", "CustomFolder", modelFile);
+            File.Exists(expectedPath).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ProcessModelClasses_MultipleMappings_ShouldRespectPriority()
+        {
+            var modelFile = "test_model.safetensors";
+            var modelFilePath = Path.Combine(_testSourcePath, modelFile);
+            File.WriteAllText(modelFilePath, "test content");
+
+            var models = new List<ModelClass>
+            {
+                new ModelClass
+                {
+                    ModelName = "test_model",
+                    AssociatedFilesInfo = new List<FileInfo> { new FileInfo(modelFilePath) },
+                    NoMetaData = false,
+                    DiffusionBaseModel = "SD 1.5",
+                    CivitaiCategory = CivitaiBaseCategories.CHARACTER,
+                    ModelType = DiffusionTypes.LORA,
+                    Tags = new List<string> { "priority_tag" }
+                }
+            };
+
+            var mapping1 = new CustomTagMap { LookForTag = new List<string> { "priority_tag" }, MapToFolder = "Folder1", Priority = 3 };
+            var mapping2 = new CustomTagMap { LookForTag = new List<string> { "priority_tag" }, MapToFolder = "Folder2", Priority = 2 };
+
+            var options = new SelectedOptions
+            {
+                TargetPath = _testTargetPath,
+                CreateBaseFolders = true,
+                IsMoveOperation = false,
+                OverrideFiles = true,
+                UseCustomMappings = true
+            };
+
+            var xmlService = new CustomTagMapXmlService();
+            xmlService.SaveMappings(new ObservableCollection<CustomTagMap> { mapping1, mapping2 });
+
+            var progress = new Progress<ProgressReport>();
+            var cts = new CancellationTokenSource();
+
+            bool result = _service.ProcessModelClasses(progress, cts.Token, models, options);
+
+            result.Should().BeFalse();
+            var expectedPath = Path.Combine(_testTargetPath, "SD 1.5", "Folder2", modelFile);
+            File.Exists(expectedPath).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ProcessModelClasses_CustomMappingWithoutBaseFolders_ShouldOmitBaseModel()
+        {
+            var modelFile = "test_model.safetensors";
+            var modelFilePath = Path.Combine(_testSourcePath, modelFile);
+            File.WriteAllText(modelFilePath, "test content");
+
+            var models = new List<ModelClass>
+            {
+                new ModelClass
+                {
+                    ModelName = "test_model",
+                    AssociatedFilesInfo = new List<FileInfo> { new FileInfo(modelFilePath) },
+                    NoMetaData = false,
+                    DiffusionBaseModel = "SD 1.5",
+                    CivitaiCategory = CivitaiBaseCategories.CHARACTER,
+                    ModelType = DiffusionTypes.LORA,
+                    Tags = new List<string> { "custom_tag" }
+                }
+            };
+
+            var customMapping = new CustomTagMap
+            {
+                LookForTag = new List<string> { "custom_tag" },
+                MapToFolder = "CustomFolder",
+                Priority = 0
+            };
+
+            var options = new SelectedOptions
+            {
+                TargetPath = _testTargetPath,
+                CreateBaseFolders = false,
+                IsMoveOperation = false,
+                OverrideFiles = true,
+                UseCustomMappings = true
+            };
+
+            var xmlService = new CustomTagMapXmlService();
+            xmlService.SaveMappings(new ObservableCollection<CustomTagMap> { customMapping });
+
+            var progress = new Progress<ProgressReport>();
+            var cts = new CancellationTokenSource();
+
+            bool result = _service.ProcessModelClasses(progress, cts.Token, models, options);
+
+            result.Should().BeFalse();
+            var expectedPath = Path.Combine(_testTargetPath, "CustomFolder", modelFile);
+            File.Exists(expectedPath).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ProcessModelClasses_TagMatching_ShouldBeCaseInsensitive()
+        {
+            var modelFile = "test_model.safetensors";
+            var modelFilePath = Path.Combine(_testSourcePath, modelFile);
+            File.WriteAllText(modelFilePath, "test content");
+
+            var models = new List<ModelClass>
+            {
+                new ModelClass
+                {
+                    ModelName = "test_model",
+                    AssociatedFilesInfo = new List<FileInfo> { new FileInfo(modelFilePath) },
+                    NoMetaData = false,
+                    DiffusionBaseModel = "SD 1.5",
+                    CivitaiCategory = CivitaiBaseCategories.CHARACTER,
+                    ModelType = DiffusionTypes.LORA,
+                    Tags = new List<string> { "CUSTOM_TAG" }
+                }
+            };
+
+            var customMapping = new CustomTagMap
+            {
+                LookForTag = new List<string> { "custom_tag" },
+                MapToFolder = "CaseFolder",
+                Priority = 0
+            };
+
+            var options = new SelectedOptions
+            {
+                TargetPath = _testTargetPath,
+                CreateBaseFolders = true,
+                IsMoveOperation = false,
+                OverrideFiles = true,
+                UseCustomMappings = true
+            };
+
+            var xmlService = new CustomTagMapXmlService();
+            xmlService.SaveMappings(new ObservableCollection<CustomTagMap> { customMapping });
+
+            var progress = new Progress<ProgressReport>();
+            var cts = new CancellationTokenSource();
+
+            bool result = _service.ProcessModelClasses(progress, cts.Token, models, options);
+
+            result.Should().BeFalse();
+            var expectedPath = Path.Combine(_testTargetPath, "SD 1.5", "CaseFolder", modelFile);
+            File.Exists(expectedPath).Should().BeTrue();
+        }
+
+        [Fact]
         public void ProcessModelClasses_ShouldSkipNonLoraFiles()
         {
             // Arrange
@@ -228,6 +485,7 @@ namespace LorasAutoSort.Test
                     Directory.Delete(path, true);
                 }
             }
+            DeleteMappingFile();
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend `FileCopyServiceTests` with mapping file cleanup
- add tests for custom tag map behaviour

## Testing
- `dotnet test LorasAutoSort.Test/LorasAutoSort.Test.csproj --verbosity minimal` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_684ada4fb0fc8332a573d21c7719b99e